### PR TITLE
fix: sidebar display on the "not found" docs-page

### DIFF
--- a/src/app/(docs)/docs/[slug]/page.tsx
+++ b/src/app/(docs)/docs/[slug]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   let post = await getDocPageBySlug(params.slug);
 
   if (!post) {
-    return notFound();
+    return {}
   }
 
   let title = `${post.title} - ${sectionAndTitle?.section ?? ""}`;
@@ -61,7 +61,9 @@ export default async function DocPage(props: Props) {
   ]);
 
   if (!post) {
-    return notFound();
+    return <>
+      {notFound()}
+    </>
   }
 
   return (


### PR DESCRIPTION
When opening a non-existent docs page, the sidebar is not visible by default - it only appears after a page reload.