### PR TITLE
chore(code-example): highlight, warning, error formatting

### DIFF
--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -223,12 +223,16 @@ export function RawHighlightedCode({
         transformerNotationErrorLevel({
           classMap: {
             warning:
-              "warning relative -mx-5 border-l-4 border-amber-400 bg-amber-300/20 pr-5 pl-8 before:absolute before:left-3 before:text-amber-400 before:content-['⚠'] after:absolute after:right-2 after:px-2 after:text-amber-400 after:bg-amber-950 after:content-['Warning'] after:max-md:hidden",
+              "warning relative -mx-5 border-l-2 border-amber-400 bg-amber-300/20 pr-5 pl-8 before:absolute before:left-3 before:text-amber-400 after:absolute after:right-2 after:px-2 after:text-amber-400 after:bg-amber-950 after:max-md:hidden",
             error:
-              "error relative -mx-5 border-l-4 border-red-400 bg-red-300/20 pr-5 pl-8 before:absolute before:left-3 before:text-red-400 before:content-['⚠'] after:absolute after:right-2 after:px-2 after:text-red-400 after:bg-red-950 after:content-['Error'] after:max-md:hidden",
+              "error relative -mx-5 border-l-2 border-red-400 bg-red-300/20 pr-5 pl-8 before:absolute before:left-3 before:text-red-400 after:absolute after:right-2 after:px-2 after:text-red-400 after:bg-red-950 after:max-md:hidden",
           },
           classActivePre:
             "[:where(&_.line)]:pl-4 [:where(&_.highlighted-line)]:pl-[calc(var(--spacing)*9-2px)]!" +
+            // Warning: Multiple line should title only first line
+            " [:where(&_.warning)]:before:content-['⚠'] [:where(&_.warning~.warning)]:before:content-[''] [:where(&_.warning)]:after:content-['Warning'] [:where(&_.warning~.warning)]:after:content-['']" +
+            // Error: Multiple line should title only first line
+            " [:where(&_.error)]:before:content-['⚠'] [:where(&_.error~.error)]:before:content-[''] [:where(&_.error)]:after:content-['Error'] [:where(&_.warning~.error)]:after:content-['']",
         }),
         highlightClasses({
           highlightedClassName:


### PR DESCRIPTION
- fixed highlight padding
- show warning and error before-after icon/text only on the first line of sibling elements